### PR TITLE
Don't reject version 1 blocks.

### DIFF
--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -654,15 +654,16 @@ func (b *BlockChain) checkBlockHeaderContext(header *wire.BlockHeader, prevNode 
 	}
 
 	if !fastAdd {
+		/* ppc:
 		// Reject version 2 blocks once a majority of the network has
 		// upgraded.  This is part of BIP0066.
-		/* ppc: if header.Version < 3 && b.isMajorityVersion(3, prevNode,
+		if header.Version < 3 && b.isMajorityVersion(3, prevNode,
 			b.chainParams.BlockRejectNumRequired) {
 
 			str := "new blocks with version %d are no longer valid"
 			str = fmt.Sprintf(str, header.Version)
 			return ruleError(ErrBlockVersionTooOld, str)
-		}*/
+		}
 
 		// Reject version 1 blocks once a majority of the network has
 		// upgraded.  This is part of BIP0034.
@@ -672,7 +673,7 @@ func (b *BlockChain) checkBlockHeaderContext(header *wire.BlockHeader, prevNode 
 			str := "new blocks with version %d are no longer valid"
 			str = fmt.Sprintf(str, header.Version)
 			return ruleError(ErrBlockVersionTooOld, str)
-		}
+		}*/
 	}
 
 	return nil


### PR DESCRIPTION
I tried to download the testnet blockchain from scratch with ppcd, and after block 114569, all the blocks were considered as orphans.

Apparently it happened because there are some blocks with version=2 in the blockchain, and there is a test in the code rejecting blocks with version=1 if there are enough blocks with version=2.

This test is in btcd to comply with BIP0034 on the Bitcoin network, but I don't think version 1 blocks have been obsoleted on the Peercoin network (all the new blocks I saw have version=1).

So this PR disables the version 1 blocks rejection, which allows ppcd to download the blockchain completely.
